### PR TITLE
fix texture target

### DIFF
--- a/src/com/android/grafika/gles/Texture2dProgram.java
+++ b/src/com/android/grafika/gles/Texture2dProgram.java
@@ -225,13 +225,13 @@ public class Texture2dProgram {
         GLES20.glBindTexture(mTextureTarget, texId);
         GlUtil.checkGlError("glBindTexture " + texId);
 
-        GLES20.glTexParameterf(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER,
+        GLES20.glTexParameterf(mTextureTarget, GLES20.GL_TEXTURE_MIN_FILTER,
                 GLES20.GL_NEAREST);
-        GLES20.glTexParameterf(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER,
+        GLES20.glTexParameterf(mTextureTarget, GLES20.GL_TEXTURE_MAG_FILTER,
                 GLES20.GL_LINEAR);
-        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S,
+        GLES20.glTexParameteri(mTextureTarget, GLES20.GL_TEXTURE_WRAP_S,
                 GLES20.GL_CLAMP_TO_EDGE);
-        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T,
+        GLES20.glTexParameteri(mTextureTarget, GLES20.GL_TEXTURE_WRAP_T,
                 GLES20.GL_CLAMP_TO_EDGE);
         GlUtil.checkGlError("glTexParameter");
 

--- a/src/com/android/grafika/gles/Texture2dProgram.java
+++ b/src/com/android/grafika/gles/Texture2dProgram.java
@@ -233,7 +233,7 @@ public class Texture2dProgram {
                 GLES20.GL_CLAMP_TO_EDGE);
         GLES20.glTexParameteri(mTextureTarget, GLES20.GL_TEXTURE_WRAP_T,
                 GLES20.GL_CLAMP_TO_EDGE);
-        GlUtil.checkGlError("glTexParameter");
+        GlUtil.checkGlError("glTexParameter "+mTextureTarget);
 
         return texId;
     }


### PR DESCRIPTION
The texture filter should match the texture target TEXTURE_2D or GL_TEXTURE_EXTERNAL_OES from constructor of class.