### PR TITLE
Updated libary to support more recent Android NDK/SDK distributions and API levels:

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,14 +16,14 @@
 apply plugin : 'com.android.application'
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion 28
   defaultConfig {
     applicationId "com.google.grafika"
     minSdkVersion 14
-    targetSdkVersion 26
+    targetSdkVersion 28
   }
 }
 
 dependencies {
-  implementation 'com.android.support:appcompat-v7:26.1.0'
+  implementation 'com.android.support:appcompat-v7:28.0.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,10 +20,6 @@
     android:versionCode="33"
     android:versionName="1.0" >
 
-    <uses-sdk
-        android:minSdkVersion="18"
-        android:targetSdkVersion="18" />
-
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 27 15:59:01 PST 2017
+#Thu Feb 21 12:11:59 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
1) Blocker Fix: latest android NDK no longer supprots 'mips64el-linux-android' ABI.

- updated classpath for gradle build tools, so gradle is not searching
for dep ABI

2) Removed API level declarations from Android Manifest file

3) Updated app-compat activity base

4) Updated gradle distribution to support API level 28 & updated
classpath

Grafika is happy and working again :)